### PR TITLE
Reflect CSS Modules classnames in snapshots

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -47,6 +47,7 @@
     "file-loader": "0.11.1",
     "fs-extra": "3.0.1",
     "html-webpack-plugin": "2.28.0",
+    "identity-obj-proxy": "3.0.0",
     "jest": "20.0.3",
     "node-sass": "^4.5.3",
     "object-assign": "4.1.1",

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -40,6 +40,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
+      "^.+\\.s?css$": "identity-obj-proxy",
     },
     "moduleDirectories": [
       "node_modules",


### PR DESCRIPTION
Mock (S)CSS file imports in such a way that when they're asked for some property, they return that same property name.

This way,
<Foo className={styles.bar} />
becomes
<Foo className="bar" />
in a snapshot!

<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
